### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.14
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.11
+  version: 0.0.14
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.3

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -1,10 +1,10 @@
 dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.15
+  version: 0.0.14
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.11
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.3
+  version: 0.0.4

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.17
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.11
+  version: 0.0.14
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.3

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.14
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.3
+  version: 0.0.4

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -1,10 +1,10 @@
 dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.14
+  version: 0.0.17
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.14
+  version: 0.0.11
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.3

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -1,11 +1,10 @@
----
 dependencies:
-- name: "conference-agenda"
-  repository: "http://jenkins-x-chartmuseum:8080"
-  version: "0.0.14"
-- name: "conference-sponsors"
-  repository: "http://jenkins-x-chartmuseum:8080"
-  version: "0.0.11"
-- name: "conference-site"
-  repository: "http://jenkins-x-chartmuseum:8080"
-  version: "0.0.3"  
+- name: conference-agenda
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.15
+- name: conference-sponsors
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.11
+- name: conference-site
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.3

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.3](https://github.com/salaboy/conference-site/releases/tag/v0.0.3) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.15](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.15) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.3](https://github.com/salaboy/conference-site/releases/tag/v0.0.3) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,5 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.3](https://github.com/salaboy/conference-site/releases/tag/v0.0.3) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) |
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,3 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.3](https://github.com/salaboy/conference-site/releases/tag/v0.0.3) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.15](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.15) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.3](https://github.com/salaboy/conference-site/releases/tag/v0.0.3) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -5,3 +5,9 @@ dependencies:
   url: https://github.com/salaboy/conference-site.git
   version: 0.0.3
   versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.3
+- host: github.com
+  owner: salaboy
+  repo: conference-agenda
+  url: https://github.com/salaboy/conference-agenda.git
+  version: 0.0.15
+  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.15

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,11 +3,5 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site.git
-  version: 0.0.3
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.3
-- host: github.com
-  owner: salaboy
-  repo: conference-agenda
-  url: https://github.com/salaboy/conference-agenda.git
-  version: 0.0.15
-  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.15
+  version: 0.0.4
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.4

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,11 +3,17 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site.git
-  version: 0.0.3
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.3
+  version: 0.0.4
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.4
 - host: github.com
   owner: salaboy
   repo: conference-agenda
   url: https://github.com/salaboy/conference-agenda.git
   version: 0.0.17
   versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17
+- host: github.com
+  owner: salaboy
+  repo: conference-sponsors
+  url: https://github.com/salaboy/conference-sponsors.git
+  version: 0.0.14
+  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,5 +3,11 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site.git
-  version: 0.0.4
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.4
+  version: 0.0.3
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.3
+- host: github.com
+  owner: salaboy
+  repo: conference-sponsors
+  url: https://github.com/salaboy/conference-sponsors.git
+  version: 0.0.14
+  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.3
 - host: github.com
   owner: salaboy
-  repo: conference-sponsors
-  url: https://github.com/salaboy/conference-sponsors.git
-  version: 0.0.14
-  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14
+  repo: conference-agenda
+  url: https://github.com/salaboy/conference-agenda.git
+  version: 0.0.17
+  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17


### PR DESCRIPTION
Update [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) from [0.0.14](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.14) to [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17)

Command run was `jx step create pr chart --name conference-agenda --version 0.0.17 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) from [0.0.11](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.11) to [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14)

Command run was `jx step create pr chart --name conference-sponsors --version 0.0.14 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-site](https://github.com/salaboy/conference-site.git) from [0.0.3](https://github.com/salaboy/conference-site/releases/tag/v0.0.3) to [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4)

Command run was `jx step create pr chart --name conference-site --version 0.0.4 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) from [0.0.14](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.14) to [0.0.15](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.15)

Command run was `jx step create pr chart --name conference-agenda --version 0.0.15 --repo https://github.com/salaboy/conference-helm-chart.git`