### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.15
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.5

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.20
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.15
+  version: 0.0.16
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.8

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.20
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.16
+  version: 0.0.17
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.9

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.15
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.6
+  version: 0.0.7

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.20
+  version: 0.0.21
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.17

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.17
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.9
+  version: 0.0.10

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.18
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.14
+  version: 0.0.15
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.4

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.19
+  version: 0.0.20
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.15

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.15
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.15
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.7
+  version: 0.0.8

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.21
+  version: 0.0.22
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.18

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.17
+  version: 0.0.18
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.14

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.18
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.10
+  version: 0.0.11

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.18
+  version: 0.0.19
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.15

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.21
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.17
+  version: 0.0.18
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.10

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.16
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.18](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.18) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.22](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.22) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.7](https://github.com/salaboy/conference-site/releases/tag/v0.0.7) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.8](https://github.com/salaboy/conference-site/releases/tag/v0.0.8) | 
 [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
 [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.9](https://github.com/salaboy/conference-site/releases/tag/v0.0.9) | 
 [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.16](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.16) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.20](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.20) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.16](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.16) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.17](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.17) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.21](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.21) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.6](https://github.com/salaboy/conference-site/releases/tag/v0.0.6) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.19](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.19) | 
 [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.18](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.18) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.15](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.15) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.10](https://github.com/salaboy/conference-site/releases/tag/v0.0.10) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
 [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.18](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.18) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.8](https://github.com/salaboy/conference-site/releases/tag/v0.0.8) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.20](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.20) | 
 [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.19](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.19) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.7](https://github.com/salaboy/conference-site/releases/tag/v0.0.7) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
 [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.9](https://github.com/salaboy/conference-site/releases/tag/v0.0.9) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
 [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.17](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.17) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) |
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.18](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.18) | 
 [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.5](https://github.com/salaboy/conference-site/releases/tag/v0.0.5) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.6](https://github.com/salaboy/conference-site/releases/tag/v0.0.6) | 
 [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
 [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.21](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.21) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.10](https://github.com/salaboy/conference-site/releases/tag/v0.0.10) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
 [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.22](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.22) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.11](https://github.com/salaboy/conference-site/releases/tag/v0.0.11) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
 [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site.git) |  | [0.0.5](https://github.com/salaboy/conference-site/releases/tag/v0.0.5) | 
 [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) |  | [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.15](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.15) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) |  | [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: conference-agenda
   url: https://github.com/salaboy/conference-agenda.git
-  version: 0.0.17
-  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17
+  version: 0.0.18
+  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.18
 - host: github.com
   owner: salaboy
   repo: conference-sponsors

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site
-  version: 0.0.9
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.9
+  version: 0.0.10
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.10
 - host: github.com
   owner: salaboy
   repo: conference-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: conference-agenda
   url: https://github.com/salaboy/conference-agenda
-  version: 0.0.21
-  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.21
+  version: 0.0.22
+  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.22
 - host: github.com
   owner: salaboy
   repo: conference-sponsors

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site.git
-  version: 0.0.6
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.6
+  version: 0.0.7
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.7
 - host: github.com
   owner: salaboy
   repo: conference-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -14,6 +14,6 @@ dependencies:
 - host: github.com
   owner: salaboy
   repo: conference-sponsors
-  url: https://github.com/salaboy/conference-sponsors.git
-  version: 0.0.16
-  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.16
+  url: https://github.com/salaboy/conference-sponsors
+  version: 0.0.17
+  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.17

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -8,9 +8,9 @@ dependencies:
 - host: github.com
   owner: salaboy
   repo: conference-agenda
-  url: https://github.com/salaboy/conference-agenda.git
-  version: 0.0.20
-  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.20
+  url: https://github.com/salaboy/conference-agenda
+  version: 0.0.21
+  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.21
 - host: github.com
   owner: salaboy
   repo: conference-sponsors

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: conference-agenda
   url: https://github.com/salaboy/conference-agenda.git
-  version: 0.0.18
-  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.18
+  version: 0.0.19
+  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.19
 - host: github.com
   owner: salaboy
   repo: conference-sponsors

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,5 +15,5 @@ dependencies:
   owner: salaboy
   repo: conference-sponsors
   url: https://github.com/salaboy/conference-sponsors
-  version: 0.0.17
-  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.17
+  version: 0.0.18
+  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.18

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site.git
-  version: 0.0.7
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.7
+  version: 0.0.8
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.8
 - host: github.com
   owner: salaboy
   repo: conference-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,5 +15,5 @@ dependencies:
   owner: salaboy
   repo: conference-sponsors
   url: https://github.com/salaboy/conference-sponsors.git
-  version: 0.0.15
-  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.15
+  version: 0.0.16
+  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.16

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,5 +15,5 @@ dependencies:
   owner: salaboy
   repo: conference-sponsors
   url: https://github.com/salaboy/conference-sponsors.git
-  version: 0.0.14
-  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14
+  version: 0.0.15
+  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.15

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: conference-agenda
   url: https://github.com/salaboy/conference-agenda.git
-  version: 0.0.19
-  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.19
+  version: 0.0.20
+  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.20
 - host: github.com
   owner: salaboy
   repo: conference-sponsors

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -2,9 +2,9 @@ dependencies:
 - host: github.com
   owner: salaboy
   repo: conference-site
-  url: https://github.com/salaboy/conference-site.git
-  version: 0.0.8
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.8
+  url: https://github.com/salaboy/conference-site
+  version: 0.0.9
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.9
 - host: github.com
   owner: salaboy
   repo: conference-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site.git
-  version: 0.0.4
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.4
+  version: 0.0.5
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.5
 - host: github.com
   owner: salaboy
   repo: conference-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site
-  version: 0.0.10
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.10
+  version: 0.0.11
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.11
 - host: github.com
   owner: salaboy
   repo: conference-agenda

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site.git
-  version: 0.0.5
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.5
+  version: 0.0.6
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.6
 - host: github.com
   owner: salaboy
   repo: conference-agenda


### PR DESCRIPTION
Update [salaboy/conference-site](https://github.com/salaboy/conference-site) from [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) to [0.0.11](https://github.com/salaboy/conference-site/releases/tag/v0.0.11)

Command run was `jx step create pr chart --name conference-site --version 0.0.11 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) from [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) to [0.0.22](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.22)

Command run was `jx step create pr chart --name conference-agenda --version 0.0.22 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) from [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) to [0.0.18](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.18)

Command run was `jx step create pr chart --name conference-sponsors --version 0.0.18 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-site](https://github.com/salaboy/conference-site) from [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) to [0.0.10](https://github.com/salaboy/conference-site/releases/tag/v0.0.10)

Command run was `jx step create pr chart --name conference-site --version 0.0.10 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) from [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) to [0.0.21](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.21)

Command run was `jx step create pr chart --name conference-agenda --version 0.0.21 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) from [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) to [0.0.17](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.17)

Command run was `jx step create pr chart --name conference-sponsors --version 0.0.17 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-site](https://github.com/salaboy/conference-site) from [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) to [0.0.9](https://github.com/salaboy/conference-site/releases/tag/v0.0.9)

Command run was `jx step create pr chart --name conference-site --version 0.0.9 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) from [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) to [0.0.16](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.16)

Command run was `jx step create pr chart --name conference-sponsors --version 0.0.16 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) from [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) to [0.0.20](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.20)

Command run was `jx step create pr chart --name conference-agenda --version 0.0.20 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-site](https://github.com/salaboy/conference-site.git) from [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) to [0.0.8](https://github.com/salaboy/conference-site/releases/tag/v0.0.8)

Command run was `jx step create pr chart --name conference-site --version 0.0.8 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-site](https://github.com/salaboy/conference-site.git) from [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) to [0.0.7](https://github.com/salaboy/conference-site/releases/tag/v0.0.7)

Command run was `jx step create pr chart --name conference-site --version 0.0.7 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) from [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) to [0.0.19](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.19)

Command run was `jx step create pr chart --name conference-agenda --version 0.0.19 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-site](https://github.com/salaboy/conference-site.git) from [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) to [0.0.6](https://github.com/salaboy/conference-site/releases/tag/v0.0.6)

Command run was `jx step create pr chart --name conference-site --version 0.0.6 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-site](https://github.com/salaboy/conference-site.git) from [0.0.4](https://github.com/salaboy/conference-site/releases/tag/v0.0.4) to [0.0.5](https://github.com/salaboy/conference-site/releases/tag/v0.0.5)

Command run was `jx step create pr chart --name conference-site --version 0.0.5 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors.git) from [0.0.14](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.14) to [0.0.15](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.15)

Command run was `jx step create pr chart --name conference-sponsors --version 0.0.15 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda.git) from [0.0.17](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.17) to [0.0.18](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.18)

Command run was `jx step create pr chart --name conference-agenda --version 0.0.18 --repo https://github.com/salaboy/conference-helm-chart.git`