### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.23
+  version: 0.0.24
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.20

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.20
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.13
+  version: 0.0.14

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.23
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.19
+  version: 0.0.20
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.13

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.13](https://github.com/salaboy/conference-site/releases/tag/v0.0.13) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.24](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.24) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.14](https://github.com/salaboy/conference-site/releases/tag/v0.0.14) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.23](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.23) | 
 [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.19](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.19) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.13](https://github.com/salaboy/conference-site/releases/tag/v0.0.13) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.23](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.23) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.20](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.20) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.24](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.24) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.19](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.19) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.13](https://github.com/salaboy/conference-site/releases/tag/v0.0.13) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.22](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.22) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.18](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.18) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.23](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.23) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.20](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.20) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,5 +15,5 @@ dependencies:
   owner: salaboy
   repo: conference-sponsors
   url: https://github.com/salaboy/conference-sponsors
-  version: 0.0.19
-  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.19
+  version: 0.0.20
+  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.20

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: conference-agenda
   url: https://github.com/salaboy/conference-agenda
-  version: 0.0.23
-  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.23
+  version: 0.0.24
+  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.24
 - host: github.com
   owner: salaboy
   repo: conference-sponsors

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site
-  version: 0.0.13
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.13
+  version: 0.0.14
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.14
 - host: github.com
   owner: salaboy
   repo: conference-agenda


### PR DESCRIPTION
Update [salaboy/conference-site](https://github.com/salaboy/conference-site) from [0.0.13](https://github.com/salaboy/conference-site/releases/tag/v0.0.13) to [0.0.14](https://github.com/salaboy/conference-site/releases/tag/v0.0.14)

Command run was `jx step create pr chart --name conference-site --version 0.0.14 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) from [0.0.23](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.23) to [0.0.24](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.24)

Command run was `jx step create pr chart --name conference-agenda --version 0.0.24 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) from [0.0.19](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.19) to [0.0.20](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.20)

Command run was `jx step create pr chart --name conference-sponsors --version 0.0.20 --repo https://github.com/salaboy/conference-helm-chart.git`