### PR TITLE
chore(deps): bump from

### DIFF
--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.24
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.20
+  version: 0.0.21
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.14

--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: conference-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.24
+  version: 0.0.25
 - name: conference-sponsors
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.21

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.14](https://github.com/salaboy/conference-site/releases/tag/v0.0.14) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.24](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.24) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.21](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.21) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.25](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.25) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.20](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.20) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,5 +3,5 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.14](https://github.com/salaboy/conference-site/releases/tag/v0.0.14) | 
-[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.23](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.23) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.19](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.19) | 
+[salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.24](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.24) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.21](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.21) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: conference-agenda
   url: https://github.com/salaboy/conference-agenda
-  version: 0.0.24
-  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.24
+  version: 0.0.25
+  versionURL: https://github.com/salaboy/conference-agenda/releases/tag/v0.0.25
 - host: github.com
   owner: salaboy
   repo: conference-sponsors

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,5 +15,5 @@ dependencies:
   owner: salaboy
   repo: conference-sponsors
   url: https://github.com/salaboy/conference-sponsors
-  version: 0.0.20
-  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.20
+  version: 0.0.21
+  versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.21


### PR DESCRIPTION
Update [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) from [0.0.24](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.24) to [0.0.25](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.25)

Command run was `jx step create pr chart --name conference-agenda --version 0.0.25 --repo https://github.com/salaboy/conference-helm-chart.git`
<hr />

Update [salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) from [0.0.20](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.20) to [0.0.21](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.21)

Command run was `jx step create pr chart --name conference-sponsors --version 0.0.21 --repo https://github.com/salaboy/conference-helm-chart.git`