### PR TITLE
chore(deps): bump https://github.com/salaboy/conference-site from 0.0.15 to 0.0.16

### DIFF
--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.21
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.15
+  version: 0.0.16

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,6 +2,6 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.14](https://github.com/salaboy/conference-site/releases/tag/v0.0.14) | 
+[salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.16](https://github.com/salaboy/conference-site/releases/tag/v0.0.16) | 
 [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.25](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.25) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.20](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.20) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.21](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.21) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: conference-site
   url: https://github.com/salaboy/conference-site
-  version: 0.0.14
-  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.14
+  version: 0.0.16
+  versionURL: https://github.com/salaboy/conference-site/releases/tag/v0.0.16
 - host: github.com
   owner: salaboy
   repo: conference-agenda


### PR DESCRIPTION
Update [salaboy/conference-site](https://github.com/salaboy/conference-site) from [0.0.15](https://github.com/salaboy/conference-site/releases/tag/v0.0.15) to [0.0.16](https://github.com/salaboy/conference-site/releases/tag/v0.0.16)

Command run was `jx step create pr chart --name conference-site --version 0.0.16 --repo https://github.com/salaboy/conference-helm-chart.git`