### PR TITLE
chore(deps): bump https://github.com/ajureeruja/conference-site from 0.0.15 to 0.0.19

### DIFF
--- a/conference/requirements.yaml
+++ b/conference/requirements.yaml
@@ -7,4 +7,4 @@ dependencies:
   version: 0.0.21
 - name: conference-site
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.15
+  version: 0.0.19

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,4 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/conference-site](https://github.com/salaboy/conference-site) |  | [0.0.14](https://github.com/salaboy/conference-site/releases/tag/v0.0.14) | 
 [salaboy/conference-agenda](https://github.com/salaboy/conference-agenda) |  | [0.0.25](https://github.com/salaboy/conference-agenda/releases/tag/v0.0.25) | 
-[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.20](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.20) | 
+[salaboy/conference-sponsors](https://github.com/salaboy/conference-sponsors) |  | [0.0.21](https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.21) | 
+[ajureeruja/conference-site](https://github.com/ajureeruja/conference-site) |  | [0.0.19](https://github.com/ajureeruja/conference-site/releases/tag/v0.0.19) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -17,3 +17,9 @@ dependencies:
   url: https://github.com/salaboy/conference-sponsors
   version: 0.0.21
   versionURL: https://github.com/salaboy/conference-sponsors/releases/tag/v0.0.21
+- host: github.com
+  owner: ajureeruja
+  repo: conference-site
+  url: https://github.com/ajureeruja/conference-site
+  version: 0.0.19
+  versionURL: https://github.com/ajureeruja/conference-site/releases/tag/v0.0.19


### PR DESCRIPTION
Update [ajureeruja/conference-site](https://github.com/ajureeruja/conference-site) from 0.0.15 to [0.0.19](https://github.com/ajureeruja/conference-site/releases/tag/v0.0.19)

Command run was `jx step create pr chart --name conference-site --version 0.0.19 --repo https://github.com/salaboy/conference-helm-chart.git`